### PR TITLE
Prepend date to audit log entries

### DIFF
--- a/pocket_protector/cli.py
+++ b/pocket_protector/cli.py
@@ -202,10 +202,11 @@ def _create_protected(path):
         raise PPCLIError('Protected file already exists: %s' % path, 2)
     open(path, 'wb').close()
     kf = KeyFile(path=path)
+    logged_kf = kf.append_to_audit_log("File Created")
     # TODO: add audit log entry for creation date
     # TODO: add audit log dates in general
-    kf.write()
-    return kf
+    logged_kf.write()
+    return logged_kf
 
 
 def _ensure_protected(path):


### PR DESCRIPTION
Hey @mahmoud, could you review this?

Saw this:
```
# TODO: add audit log entry for creation date
# TODO: add audit log dates in general
```
so I took a stab at it - seems to work.

Output from `test-file-key.py`
```
generated file:
new_domain:
  secret-hello: AA4H3lKR3LcsGG4Vq7ZInUrQn+oVJ8wQ0vlJ4fNBUglLOJT+TWKjZeaaueJyV9qd5gUeIZUxyxjLhvamvQ==
  meta:
    public-key: AFVmDO/EBMXvvN8kdT7u/LMvn45V8+RSH+imutTrzlh/
    owners:
      alice@example.com: AJ/DYPhXXp/CLekzekV45AZ4wyqhAY2N0wDwIlF++HIfm7ULQbSb48dDxDg3527g9wpUjhDY5lJOFFPZPs7QOqV8Oq5rMs8Ybelec3ZCbJFX
      bob@example.com: AADJGKFt+O9idTAlCWMmhz8NO/lRgGtEVYjJX2pl08QM1VKw7DvS7+uptzLihpPze6UiK1whwUN14L/WCkXI5GH1FmQc17MZVYrTImoRamSz
key-custodians:
  alice@example.com:
    pwdkm: AA8vjUoWqvxq4zjy9Yk7u7Wwaxk7a7icfxGT3BGLCQnnkZbmmZU4BH8=
  bob@example.com:
    pwdkm: ALwhDZN1yd64c5r8smdxQ6X5lgQKQNvajlGwu0/1Bv0j5HN41tx43Xg=
audit-log:
- 2018-03-31 created key custodian bob@example.com
- 2018-03-31 created domain new_domain with owner bob@example.com
- 2018-03-31 added secret hello in new_domain
- 2018-03-31 updated secret hello in new_domain
- 2018-03-31 set secret hello in new_domain
- 2018-03-31 removed secret hello from new_domain
- 2018-03-31 set secret hello in new_domain
- 2018-03-31 set secret hello in new_domain
- 2018-03-31 created key custodian alice@example.com
- 2018-03-31 bob@example.com added owner alice@example.com to new_domain
- 2018-03-31 rotated key for domain new_domain
- 2018-03-31 updated key custodian passphrase for bob@example.com (updated domains
  -- new_domain)
```